### PR TITLE
Fix exclude syntax for better handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "rcr"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "base16ct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rcr"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "A file checking tool"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Usage
     
     OPTIONS:
         -d, --dat-file <DAT_FILE>  name of the dat file to use as reference [env: RCR_DATFILE=]
-        -e, --exclude <EXCLUDE>    exclude file suffixes when scanning, overrides any files on command line [env: RCR_EXCLUDE=]
+        -e, --exclude <EXCLUDE>    comma seperated list of suffixes to exclude when scanning,
+                                   overrides any files on command line [env: RCR_EXCLUDE=]
         -f, --fast                 fast match mode for single rom games,
                                    may show incorrect names if multiple identical hashes [env: RCR_FAST=]
         -m, --method <METHOD>      method to use for matching reference entries


### PR DESCRIPTION
before you had to add multiple --exclude specifications which was confusing and precluded usage in environment variables. Moved to a comma separated list instead for ease of use.